### PR TITLE
Fix HUD Scaling issues

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -400,7 +400,6 @@ debug_slowmode={
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
-2d/snap/snap_2d_transforms_to_pixel=true
 environment/defaults/default_environment="res://default_env.tres"
 
 [tiled_importer]

--- a/project.godot
+++ b/project.godot
@@ -400,6 +400,7 @@ debug_slowmode={
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
+2d/snap/snap_2d_transforms_to_pixel=true
 environment/defaults/default_environment="res://default_env.tres"
 
 [tiled_importer]

--- a/project.godot
+++ b/project.godot
@@ -71,10 +71,8 @@ mc="*res://src/UI/MouseCursor.gd"
 
 [display]
 
-window/size/viewport_width=1280
-window/size/viewport_height=720
-window/size/window_width_override=1920
-window/size/window_height_override=1080
+window/size/viewport_width=960
+window/size/viewport_height=540
 
 [editor]
 

--- a/src/UI/HUD/HUD.gd
+++ b/src/UI/HUD/HUD.gd
@@ -302,3 +302,4 @@ func setup_lost_bars(hp, xp): #needs to be done so that update can tell that it'
 
 func on_viewport_size_changed():
 	size = get_tree().get_root().size / world.resolution_scale
+	position = Vector2(0, 0)

--- a/src/UI/HUD/HUD.tscn
+++ b/src/UI/HUD/HUD.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=61 format=3 uid="uid://dulcn8jx6cd3y"]
+[gd_scene load_steps=57 format=3 uid="uid://dulcn8jx6cd3y"]
 
 [ext_resource type="Script" uid="uid://getspcndfk4e" path="res://src/UI/HUD/HUD.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://c7wyw4y3jdl7j" path="res://assets/UI/NumberNew.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://do03ns87tmu82" path="res://assets/UI/HUD/Background.png" id="3"]
 [ext_resource type="PackedScene" uid="uid://2st5whfy4i8b" path="res://src/UI/HUD/AmmoCount.tscn" id="3_0touq"]
 [ext_resource type="Texture2D" uid="uid://4wopjt8nlvp1" path="res://assets/UI/HUD/HpProgress.png" id="4"]
-[ext_resource type="Shader" uid="uid://bfsl4o8u1wb4b" path="res://src/Shader/SimpleOutline.gdshader" id="4_7s250"]
 [ext_resource type="Texture2D" uid="uid://nkjwbokhsfxc" path="res://assets/UI/HUD/XpProgress.png" id="5"]
-[ext_resource type="Texture2D" uid="uid://cg54u1k8whqg3" path="res://assets/Gun/TurnstileJumper.png" id="5_ovnkw"]
 [ext_resource type="Texture2D" uid="uid://bp2x66vhi4s1f" path="res://assets/UI/HUD/XpFlash.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://cn3hthxv2o1lq" path="res://assets/UI/HUD/HpLost.png" id="7"]
 [ext_resource type="Texture2D" uid="uid://bqejmth0dsfvu" path="res://assets/UI/HUD/CooldownProgress.png" id="8"]
@@ -25,7 +23,6 @@
 [ext_resource type="Texture2D" uid="uid://xdyjjbvv4pjx" path="res://assets/UI/HUD/Bullet.png" id="20_rfbaj"]
 [ext_resource type="Texture2D" uid="uid://s3vaw1gr2atc" path="res://assets/Gun/MPistolIconSmall.png" id="21_1f167"]
 [ext_resource type="Shader" uid="uid://c8nu6mhx6pu3j" path="res://src/Shader/SimpleOutlineWeaponWheel.gdshader" id="21_n4pkm"]
-[ext_resource type="Texture2D" uid="uid://cl1nlp1q780sk" path="res://assets/UI/HUD/rotatetemplate.png" id="26_8nsof"]
 
 [sub_resource type="Animation" id="Animation_rfbaj"]
 resource_name = "BulletShoot"
@@ -365,7 +362,7 @@ step = 0.1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("WeaponWheel:frame")
+tracks/0/path = NodePath("WheelPivot/WeaponWheel:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -377,7 +374,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("WeaponWheel/Bullet1:position")
+tracks/1/path = NodePath("WheelPivot/WeaponWheel/Bullet1:position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -389,7 +386,7 @@ tracks/1/keys = {
 tracks/2/type = "value"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("WeaponWheel/Bullet2:position")
+tracks/2/path = NodePath("WheelPivot/WeaponWheel/Bullet2:position")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
@@ -401,7 +398,7 @@ tracks/2/keys = {
 tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("WeaponWheel/Bullet3:position")
+tracks/3/path = NodePath("WheelPivot/WeaponWheel/Bullet3:position")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
@@ -413,7 +410,7 @@ tracks/3/keys = {
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("WeaponWheel/Bullet4:position")
+tracks/4/path = NodePath("WheelPivot/WeaponWheel/Bullet4:position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
@@ -425,7 +422,7 @@ tracks/4/keys = {
 tracks/5/type = "value"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("WeaponWheel/Bullet5:position")
+tracks/5/path = NodePath("WheelPivot/WeaponWheel/Bullet5:position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
@@ -437,7 +434,7 @@ tracks/5/keys = {
 tracks/6/type = "value"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("WeaponWheel/Bullet6:position")
+tracks/6/path = NodePath("WheelPivot/WeaponWheel/Bullet6:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = {
@@ -454,7 +451,7 @@ step = 0.1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("WeaponWheel:frame")
+tracks/0/path = NodePath("WheelPivot/WeaponWheel:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -466,7 +463,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("WeaponWheel/Bullet1:position")
+tracks/1/path = NodePath("WheelPivot/WeaponWheel/Bullet1:position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -478,7 +475,7 @@ tracks/1/keys = {
 tracks/2/type = "value"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("WeaponWheel/Bullet2:position")
+tracks/2/path = NodePath("WheelPivot/WeaponWheel/Bullet2:position")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
@@ -490,7 +487,7 @@ tracks/2/keys = {
 tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("WeaponWheel/Bullet3:position")
+tracks/3/path = NodePath("WheelPivot/WeaponWheel/Bullet3:position")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
@@ -502,7 +499,7 @@ tracks/3/keys = {
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("WeaponWheel/Bullet4:position")
+tracks/4/path = NodePath("WheelPivot/WeaponWheel/Bullet4:position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
@@ -514,7 +511,7 @@ tracks/4/keys = {
 tracks/5/type = "value"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("WeaponWheel/Bullet5:position")
+tracks/5/path = NodePath("WheelPivot/WeaponWheel/Bullet5:position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
@@ -526,7 +523,7 @@ tracks/5/keys = {
 tracks/6/type = "value"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("WeaponWheel/Bullet6:position")
+tracks/6/path = NodePath("WheelPivot/WeaponWheel/Bullet6:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = {
@@ -541,103 +538,103 @@ length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("WeaponWheel:frame")
+tracks/0/path = NodePath("WheelPivot/WeaponWheel:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
-"values": [0]
+"values": [6]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("WeaponWheel/Bullet1:position")
+tracks/1/path = NodePath("WheelPivot/WeaponWheel/Bullet1:position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(420, 164)]
+"values": [Vector2(-19, 19)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("WeaponWheel/Bullet2:position")
+tracks/2/path = NodePath("WheelPivot/WeaponWheel/Bullet2:position")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(433, 186)]
+"values": [Vector2(7, 25)]
 }
 tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("WeaponWheel/Bullet3:position")
+tracks/3/path = NodePath("WheelPivot/WeaponWheel/Bullet3:position")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(459, 186)]
+"values": [Vector2(25, 7)]
 }
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("WeaponWheel/Bullet4:position")
+tracks/4/path = NodePath("WheelPivot/WeaponWheel/Bullet4:position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(472, 164)]
+"values": [Vector2(19, -19)]
 }
 tracks/5/type = "value"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("WeaponWheel/Bullet5:position")
+tracks/5/path = NodePath("WheelPivot/WeaponWheel/Bullet5:position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(459, 142)]
+"values": [Vector2(-7, -25)]
 }
 tracks/6/type = "value"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("WeaponWheel/Bullet6:position")
+tracks/6/path = NodePath("WheelPivot/WeaponWheel/Bullet6:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(433, 142)]
+"values": [Vector2(-25, -7)]
 }
 tracks/7/type = "value"
 tracks/7/imported = false
 tracks/7/enabled = true
-tracks/7/path = NodePath("WeaponWheel:position")
+tracks/7/path = NodePath("WheelPivot/WeaponWheel:position")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(446, 164)]
+"values": [Vector2(0, 0)]
 }
 tracks/8/type = "value"
 tracks/8/imported = false
 tracks/8/enabled = true
-tracks/8/path = NodePath("WeaponWheel:visible")
+tracks/8/path = NodePath("WheelPivot/WeaponWheel:visible")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/keys = {
@@ -661,26 +658,26 @@ step = 0.1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("WeaponWheel:position")
+tracks/0/path = NodePath("WheelPivot/WeaponWheel:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.2, 0.3, 0.4),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1),
 "update": 0,
-"values": [Vector2(510, 100), Vector2(484, 106), Vector2(462, 116), Vector2(452, 138), Vector2(446, 164)]
+"values": [Vector2(0, -64), Vector2(-26, -58), Vector2(-48, -48), Vector2(-58, -26), Vector2(-64, 0)]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("WeaponWheel:visible")
+tracks/1/path = NodePath("WheelPivot/WeaponWheel:visible")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 1),
 "update": 1,
-"values": [true]
+"values": [true, true]
 }
 
 [sub_resource type="Animation" id="Animation_mudxy"]
@@ -690,26 +687,26 @@ step = 0.1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("WeaponWheel:position")
+tracks/0/path = NodePath("WheelPivot/WeaponWheel:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 0.1, 0.2, 0.3, 0.4),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1),
 "update": 0,
-"values": [Vector2(446, 164), Vector2(452, 138), Vector2(462, 116), Vector2(484, 106), Vector2(510, 100)]
+"values": [Vector2(-64, 0), Vector2(-58, -26), Vector2(-48, -48), Vector2(-26, -58), Vector2(0, -64)]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("WeaponWheel:visible")
+tracks/1/path = NodePath("WheelPivot/WeaponWheel:visible")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0.4, 0.4001, 0.4002),
-"transitions": PackedFloat32Array(1, 1, 1),
+"times": PackedFloat32Array(0, 0.4, 0.4001, 0.4002),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 1,
-"values": [false, false, false]
+"values": [true, false, false, false]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_vpvr1"]
@@ -718,14 +715,6 @@ _data = {
 &"TiltIn": SubResource("Animation_ice8w"),
 &"TiltOut": SubResource("Animation_mudxy")
 }
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_4y4ox"]
-shader = ExtResource("4_7s250")
-shader_parameter/color = Color(1, 1, 1, 1)
-shader_parameter/width = 1.0
-shader_parameter/pattern = 0
-shader_parameter/inside = false
-shader_parameter/add_margins = true
 
 [sub_resource type="Animation" id="Animation_4nlwx"]
 resource_name = "Flash"
@@ -748,7 +737,7 @@ length = 0.2
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("HBox/Base/Xp/Flash:modulate")
+tracks/0/path = NodePath("Base/Xp/Flash:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -764,47 +753,42 @@ _data = {
 &"XpFlash": SubResource("2")
 }
 
-[node name="HUD" type="MarginContainer" node_paths=PackedStringArray("gun", "ao", "hp_node", "xp_node", "cd", "ammo", "mon")]
+[node name="HUD" type="Control" node_paths=PackedStringArray("gun", "ao", "hp_node", "xp_node", "cd", "ammo", "mon")]
+layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_bottom = 2.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-theme_override_constants/margin_left = 16
-theme_override_constants/margin_top = 16
-theme_override_constants/margin_right = 16
-theme_override_constants/margin_bottom = 16
 script = ExtResource("1")
-gun = NodePath("HBox/Gun")
-ao = NodePath("HBox/Gun/AmmoCount")
-hp_node = NodePath("HBox/Base/Hp")
-xp_node = NodePath("HBox/Base/Xp")
-cd = NodePath("HBox/Base/Cooldown")
-ammo = NodePath("HBox/Base/Ammo")
-mon = NodePath("HBox/Base/Money")
+gun = NodePath("Gun")
+ao = NodePath("Gun/AmmoCount")
+hp_node = NodePath("Base/Hp")
+xp_node = NodePath("Base/Xp")
+cd = NodePath("Base/Cooldown")
+ammo = NodePath("Base/Ammo")
+mon = NodePath("Base/Money")
 
-[node name="HBox" type="Control" parent="."]
-layout_mode = 2
-size_flags_vertical = 0
-
-[node name="Base" type="Control" parent="HBox"]
+[node name="Base" type="Control" parent="."]
 layout_mode = 2
 anchors_preset = 0
-offset_bottom = 24.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 16.0
+offset_bottom = 16.0
 
-[node name="Back" type="Sprite2D" parent="HBox/Base"]
+[node name="Back" type="Sprite2D" parent="Base"]
 texture = ExtResource("3")
 centered = false
 
-[node name="Hp" type="Control" parent="HBox/Base"]
+[node name="Hp" type="Control" parent="Base"]
 layout_mode = 2
 anchors_preset = 0
 offset_bottom = 24.0
 mouse_filter = 2
 
-[node name="Lost" type="TextureProgressBar" parent="HBox/Base/Hp"]
+[node name="Lost" type="TextureProgressBar" parent="Base/Hp"]
 layout_mode = 0
 offset_left = 32.0
 offset_top = 3.0
@@ -814,11 +798,11 @@ mouse_filter = 2
 value = 50.0
 texture_progress = ExtResource("7")
 
-[node name="Cap" type="Sprite2D" parent="HBox/Base/Hp/Lost"]
+[node name="Cap" type="Sprite2D" parent="Base/Hp/Lost"]
 position = Vector2(19, 2)
 texture = ExtResource("15")
 
-[node name="Progress" type="TextureProgressBar" parent="HBox/Base/Hp"]
+[node name="Progress" type="TextureProgressBar" parent="Base/Hp"]
 layout_mode = 0
 offset_left = 32.0
 offset_top = 3.0
@@ -828,11 +812,11 @@ mouse_filter = 2
 value = 50.0
 texture_progress = ExtResource("4")
 
-[node name="Cap" type="Sprite2D" parent="HBox/Base/Hp/Progress"]
+[node name="Cap" type="Sprite2D" parent="Base/Hp/Progress"]
 position = Vector2(19, 2)
 texture = ExtResource("10")
 
-[node name="Num1" type="Sprite2D" parent="HBox/Base/Hp"]
+[node name="Num1" type="Sprite2D" parent="Base/Hp"]
 position = Vector2(12, 0)
 texture = ExtResource("2")
 centered = false
@@ -840,7 +824,7 @@ hframes = 11
 vframes = 6
 frame = 64
 
-[node name="Num2" type="Sprite2D" parent="HBox/Base/Hp"]
+[node name="Num2" type="Sprite2D" parent="Base/Hp"]
 position = Vector2(20, 0)
 texture = ExtResource("2")
 centered = false
@@ -848,13 +832,13 @@ hframes = 11
 vframes = 6
 frame = 64
 
-[node name="Xp" type="Control" parent="HBox/Base"]
+[node name="Xp" type="Control" parent="Base"]
 layout_mode = 2
 anchors_preset = 0
 offset_bottom = 24.0
 mouse_filter = 2
 
-[node name="Lost" type="TextureProgressBar" parent="HBox/Base/Xp"]
+[node name="Lost" type="TextureProgressBar" parent="Base/Xp"]
 layout_mode = 0
 offset_left = 28.0
 offset_top = 11.0
@@ -864,11 +848,11 @@ mouse_filter = 2
 value = 50.0
 texture_progress = ExtResource("7")
 
-[node name="Cap" type="Sprite2D" parent="HBox/Base/Xp/Lost"]
+[node name="Cap" type="Sprite2D" parent="Base/Xp/Lost"]
 position = Vector2(19, 2)
 texture = ExtResource("15")
 
-[node name="Progress" type="TextureProgressBar" parent="HBox/Base/Xp"]
+[node name="Progress" type="TextureProgressBar" parent="Base/Xp"]
 layout_mode = 0
 offset_left = 28.0
 offset_top = 11.0
@@ -878,37 +862,37 @@ mouse_filter = 2
 value = 50.0
 texture_progress = ExtResource("5")
 
-[node name="Cap" type="Sprite2D" parent="HBox/Base/Xp/Progress"]
+[node name="Cap" type="Sprite2D" parent="Base/Xp/Progress"]
 position = Vector2(19, 2)
 texture = ExtResource("13_kgt4n")
 
-[node name="Flash" type="Sprite2D" parent="HBox/Base/Xp"]
+[node name="Flash" type="Sprite2D" parent="Base/Xp"]
 modulate = Color(1, 1, 1, 0)
 position = Vector2(28, 11)
 texture = ExtResource("6")
 centered = false
 
-[node name="Num" type="Sprite2D" parent="HBox/Base/Xp"]
+[node name="Num" type="Sprite2D" parent="Base/Xp"]
 position = Vector2(20, 12)
 texture = ExtResource("2")
 hframes = 11
 vframes = 6
 frame = 56
 
-[node name="Max" type="Sprite2D" parent="HBox/Base/Xp"]
+[node name="Max" type="Sprite2D" parent="Base/Xp"]
 visible = false
 z_index = 1
 position = Vector2(25, 10)
 texture = ExtResource("13")
 centered = false
 
-[node name="Cooldown" type="Control" parent="HBox/Base"]
+[node name="Cooldown" type="Control" parent="Base"]
 layout_mode = 2
 anchors_preset = 0
 offset_bottom = 24.0
 mouse_filter = 2
 
-[node name="Progress" type="TextureProgressBar" parent="HBox/Base/Cooldown"]
+[node name="Progress" type="TextureProgressBar" parent="Base/Cooldown"]
 layout_mode = 0
 offset_left = 25.0
 offset_top = 19.0
@@ -918,17 +902,17 @@ mouse_filter = 2
 value = 50.0
 texture_progress = ExtResource("8")
 
-[node name="Cap" type="Sprite2D" parent="HBox/Base/Cooldown/Progress"]
+[node name="Cap" type="Sprite2D" parent="Base/Cooldown/Progress"]
 position = Vector2(18.5, 1)
 texture = ExtResource("17_iwa0c")
 
-[node name="Money" type="Control" parent="HBox/Base"]
+[node name="Money" type="Control" parent="Base"]
 layout_mode = 2
 anchors_preset = 0
 offset_bottom = 24.0
 mouse_filter = 2
 
-[node name="Num1" type="Sprite2D" parent="HBox/Base/Money"]
+[node name="Num1" type="Sprite2D" parent="Base/Money"]
 position = Vector2(8, 19)
 texture = ExtResource("14")
 centered = false
@@ -937,7 +921,7 @@ hframes = 10
 vframes = 2
 frame = 10
 
-[node name="Num2" type="Sprite2D" parent="HBox/Base/Money"]
+[node name="Num2" type="Sprite2D" parent="Base/Money"]
 position = Vector2(12, 19)
 texture = ExtResource("14")
 centered = false
@@ -946,7 +930,7 @@ hframes = 10
 vframes = 2
 frame = 10
 
-[node name="Num3" type="Sprite2D" parent="HBox/Base/Money"]
+[node name="Num3" type="Sprite2D" parent="Base/Money"]
 position = Vector2(16, 19)
 texture = ExtResource("14")
 centered = false
@@ -955,199 +939,167 @@ hframes = 10
 vframes = 2
 frame = 10
 
-[node name="Front" type="Sprite2D" parent="HBox/Base"]
+[node name="Front" type="Sprite2D" parent="Base"]
 texture = ExtResource("9")
 centered = false
 
-[node name="Ammo" type="Control" parent="HBox/Base"]
+[node name="Ammo" type="Control" parent="Base"]
 anchors_preset = 0
 offset_right = 40.0
 offset_bottom = 40.0
 
-[node name="Back" type="Sprite2D" parent="HBox/Base/Ammo"]
+[node name="Back" type="Sprite2D" parent="Base/Ammo"]
 position = Vector2(83, 6)
 texture = ExtResource("16_xjeta")
 
-[node name="BulletTop" type="Sprite2D" parent="HBox/Base/Ammo"]
+[node name="BulletTop" type="Sprite2D" parent="Base/Ammo"]
 position = Vector2(83, 6)
 texture = ExtResource("17_g36jn")
 hframes = 8
 vframes = 7
 frame = 2
 
-[node name="BulletBottom" type="Sprite2D" parent="HBox/Base/Ammo"]
+[node name="BulletBottom" type="Sprite2D" parent="Base/Ammo"]
 position = Vector2(83, 6)
 texture = ExtResource("17_g36jn")
 hframes = 8
 vframes = 7
 frame = 11
 
-[node name="TopAnimator" type="AnimationPlayer" parent="HBox/Base/Ammo"]
+[node name="TopAnimator" type="AnimationPlayer" parent="Base/Ammo"]
 libraries = {
 &"": SubResource("AnimationLibrary_8nsof")
 }
 
-[node name="BottomAnimator" type="AnimationPlayer" parent="HBox/Base/Ammo"]
+[node name="BottomAnimator" type="AnimationPlayer" parent="Base/Ammo"]
 libraries = {
 &"": SubResource("AnimationLibrary_xjeta")
 }
 
-[node name="Fly" type="Marker2D" parent="HBox/Base/Ammo"]
+[node name="Fly" type="Marker2D" parent="Base/Ammo"]
 position = Vector2(67, -18)
 
-[node name="Gun" type="Control" parent="HBox"]
-custom_minimum_size = Vector2(0, 24)
-layout_mode = 2
-anchors_preset = 0
-offset_left = 4.0
-offset_right = 4.0
-offset_bottom = 24.0
+[node name="Gun" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 0
+grow_vertical = 0
+size_flags_horizontal = 8
+size_flags_vertical = 8
 mouse_filter = 2
 
-[node name="GunIcon" parent="HBox/Gun" instance=ExtResource("11")]
+[node name="GunIcon" parent="Gun" instance=ExtResource("11")]
 visible = false
 layout_mode = 0
-offset_left = 380.0
-offset_top = 216.0
-offset_right = 420.0
-offset_bottom = 256.0
+offset_left = -109.0
+offset_top = -65.0
+offset_right = -69.0
+offset_bottom = -25.0
 
-[node name="WeaponWheel" type="Sprite2D" parent="HBox/Gun"]
+[node name="WheelPivot" type="Control" parent="Gun"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_top = -65.0
+offset_bottom = -65.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+
+[node name="WeaponWheel" type="Sprite2D" parent="Gun/WheelPivot"]
+unique_name_in_owner = true
 visible = false
-position = Vector2(446, 164)
 texture = ExtResource("19_g36jn")
 hframes = 8
+frame = 6
 
-[node name="Bullet1" type="Sprite2D" parent="HBox/Gun/WeaponWheel"]
-position = Vector2(420, 164)
+[node name="Bullet1" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel"]
+position = Vector2(-19, 19)
 texture = ExtResource("20_rfbaj")
 
-[node name="Gun" type="Sprite2D" parent="HBox/Gun/WeaponWheel/Bullet1"]
+[node name="Gun" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel/Bullet1"]
 material = SubResource("ShaderMaterial_8nsof")
 texture = ExtResource("21_1f167")
 
-[node name="Bullet2" type="Sprite2D" parent="HBox/Gun/WeaponWheel"]
-position = Vector2(433, 186)
+[node name="Bullet2" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel"]
+position = Vector2(7, 25)
 texture = ExtResource("20_rfbaj")
 
-[node name="Gun" type="Sprite2D" parent="HBox/Gun/WeaponWheel/Bullet2"]
+[node name="Gun" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel/Bullet2"]
 material = SubResource("ShaderMaterial_lv56q")
 texture = ExtResource("21_1f167")
 
-[node name="Bullet3" type="Sprite2D" parent="HBox/Gun/WeaponWheel"]
-position = Vector2(459, 186)
+[node name="Bullet3" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel"]
+position = Vector2(25, 7)
 texture = ExtResource("20_rfbaj")
 
-[node name="Gun" type="Sprite2D" parent="HBox/Gun/WeaponWheel/Bullet3"]
+[node name="Gun" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel/Bullet3"]
 material = SubResource("ShaderMaterial_n4pkm")
 texture = ExtResource("21_1f167")
 
-[node name="Bullet4" type="Sprite2D" parent="HBox/Gun/WeaponWheel"]
-position = Vector2(472, 164)
+[node name="Bullet4" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel"]
+position = Vector2(19, -19)
 texture = ExtResource("20_rfbaj")
 
-[node name="Gun" type="Sprite2D" parent="HBox/Gun/WeaponWheel/Bullet4"]
+[node name="Gun" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel/Bullet4"]
 material = SubResource("ShaderMaterial_vpvr1")
 texture = ExtResource("21_1f167")
 
-[node name="Bullet5" type="Sprite2D" parent="HBox/Gun/WeaponWheel"]
-position = Vector2(459, 142)
+[node name="Bullet5" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel"]
+position = Vector2(-7, -25)
 texture = ExtResource("20_rfbaj")
 
-[node name="Gun" type="Sprite2D" parent="HBox/Gun/WeaponWheel/Bullet5"]
+[node name="Gun" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel/Bullet5"]
 material = SubResource("ShaderMaterial_vg0wx")
 texture = ExtResource("21_1f167")
 
-[node name="Bullet6" type="Sprite2D" parent="HBox/Gun/WeaponWheel"]
-position = Vector2(433, 142)
+[node name="Bullet6" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel"]
+position = Vector2(-25, -7)
 texture = ExtResource("20_rfbaj")
 
-[node name="Gun" type="Sprite2D" parent="HBox/Gun/WeaponWheel/Bullet6"]
+[node name="Gun" type="Sprite2D" parent="Gun/WheelPivot/WeaponWheel/Bullet6"]
 material = SubResource("ShaderMaterial_eexsr")
 texture = ExtResource("21_1f167")
 
-[node name="WeaponWheelAnimator" type="AnimationPlayer" parent="HBox/Gun"]
+[node name="WeaponWheelAnimator" type="AnimationPlayer" parent="Gun"]
+unique_name_in_owner = true
 libraries = {
 &"": SubResource("AnimationLibrary_mudxy")
 }
 
-[node name="WeaponWheelTiltAnimator" type="AnimationPlayer" parent="HBox/Gun"]
+[node name="WeaponWheelTiltAnimator" type="AnimationPlayer" parent="Gun"]
+unique_name_in_owner = true
 libraries = {
 &"": SubResource("AnimationLibrary_vpvr1")
 }
 
-[node name="Timer" type="Timer" parent="HBox/Gun/WeaponWheelTiltAnimator"]
+[node name="Timer" type="Timer" parent="Gun/WeaponWheelTiltAnimator"]
 one_shot = true
 
-[node name="AmmoCount" parent="HBox/Gun" instance=ExtResource("3_0touq")]
+[node name="AmmoCount" parent="Gun" instance=ExtResource("3_0touq")]
 visible = false
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0
-offset_left = 48.0
-offset_top = 8.0
-offset_right = -384.0
-offset_bottom = 0.0
+offset_left = -116.0
+offset_top = -43.0
+offset_right = -68.0
+offset_bottom = -27.0
 grow_horizontal = 1
 grow_vertical = 1
 
-[node name="HBox" type="HBoxContainer" parent="HBox/Gun"]
-visible = false
-layout_mode = 0
-offset_left = 104.0
-offset_top = 8.0
-offset_right = 260.0
-offset_bottom = 24.0
-mouse_filter = 2
-
-[node name="Placeholder" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder2" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder3" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder4" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder5" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder6" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder7" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Placeholder8" type="TextureRect" parent="HBox/Gun/HBox"]
-material = SubResource("ShaderMaterial_4y4ox")
-layout_mode = 2
-texture = ExtResource("5_ovnkw")
-
-[node name="Sprite2D" type="Sprite2D" parent="HBox/Gun"]
-visible = false
-position = Vector2(478, 196)
-texture = ExtResource("26_8nsof")
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+unique_name_in_owner = true
 libraries = {
 &"": SubResource("AnimationLibrary_2a4ya")
 }
 
-[connection signal="timeout" from="HBox/Gun/WeaponWheelTiltAnimator/Timer" to="." method="_on_Timer_timeout"]
+[connection signal="timeout" from="Gun/WeaponWheelTiltAnimator/Timer" to="." method="_on_Timer_timeout"]

--- a/src/World.tscn
+++ b/src/World.tscn
@@ -27,8 +27,6 @@ z_index = 1
 [node name="UILayer" type="CanvasLayer" parent="."]
 process_mode = 3
 layer = 2
-scale = Vector2(2, 2)
-transform = Transform2D(2, 0, 0, 2, 0, 0)
 
 [node name="EditorLayer" type="CanvasLayer" parent="."]
 layer = 3


### PR DESCRIPTION
* Fix HUD being displaced when viewport size changes
* Set project display size to intended native res: 960x540
* Remove erroneous UILayer default scale and transform

Fix weapon wheel:
* Put the weaponwheel components under the "WheelPivot" control node that automatically adjusts to bottom right corner of the screen
* Adjust the WeaponWheel animations themselves to correctly use the local coordinate system, so moving the pivot does not affect the animation
* Use @onready for weapon wheel nodes

Misc:
* Remove some unused hbox code
* Connect juniper signals using the simpler node.signal.connect(function) format
* turn animation player into an @onready as well
* Use unique names for a few nodes in the HUD

Video of the fixes:

https://github.com/user-attachments/assets/fcfa5178-8d20-47bd-a977-8d35922e6795



Notes:
I have not preserved the position of where the weapon wheel is supposed to appear at, since I dunno if I've seen it work as intended. If the placement is not ideal, you should move the "WheelPivot" to change its positioning. The animations themselves are correctly adjusted to that pivot node's local coordinate system so things shouldn't break.
