### PR TITLE
Fix jump being interrupted when falling (coyote time)

### DIFF
--- a/src/Player/Knockback.gd
+++ b/src/Player/Knockback.gd
@@ -35,7 +35,7 @@ func set_move_dir():
 	var move_dir = Vector2.ZERO
 	if pc.can_input:
 		move_dir= Vector2(Input.get_action_strength("move_right") - Input.get_action_strength("move_left"), 0.0)
-		if mm.coyote_timer.time_left > 0.0 and Input.is_action_just_pressed("jump"):
+		if not mm.coyote_timer.is_stopped() and Input.is_action_just_pressed("jump"):
 			move_dir = Vector2(move_dir.x, -1.0)
 	pc.move_dir = move_dir
 


### PR DESCRIPTION
Fix move_dir.y not being set to -1.0 when jumping, resulting in incorrectly interrupted jumps especially during coyote time (for example, due to falling when trying to jump)
Apply the fix to both Jump.gd and LongJump.gd

Note that Jump and LongJump are so similar they should probably be merged to reduce issues due to code duplication, but I'd rather do that in a separate PR