### PR TITLE
Fix Greyscreen caused by resizing the window

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -72,8 +72,8 @@ f="*res://src/Utility/Finder.gd"
 
 [display]
 
-window/size/viewport_width=960
-window/size/viewport_height=540
+window/size/viewport_width=480
+window/size/viewport_height=270
 
 [editor]
 

--- a/src/UI/Options/Settings.gd
+++ b/src/UI/Options/Settings.gd
@@ -48,7 +48,6 @@ func on_displaymode_changed(index: int):
 	match index:
 		0: #windowed
 			win.mode = Window.MODE_WINDOWED
-			win.size = Vector2i(1920, 1080) #TODO, change later on for smaller screens
 			win.move_to_center()
 			win.borderless = false
 		1: #borderless

--- a/src/World.gd
+++ b/src/World.gd
@@ -44,6 +44,14 @@ func _ready():
 
 	SaveSystem.load_options()
 
+	# Grab the default viewport width and height
+	var width = ProjectSettings.get_setting("display/window/size/viewport_width")
+	var height = ProjectSettings.get_setting("display/window/size/viewport_height")
+
+	# Apply them to the root window as the minimum size
+	var main_window = get_tree().get_root()
+	main_window.set_min_size(Vector2i(width, height))
+
 
 
 func get_internal_version() -> String:
@@ -264,7 +272,6 @@ func clear_spawn_layers():
 func on_viewport_size_changed():
 	if viewport_size_ignore:
 		return
-	print("viewport size changed")
 	var viewport_size = get_tree().get_root().size
 	
 	var tiles_visible_y = 15.0
@@ -273,9 +280,7 @@ func on_viewport_size_changed():
 		resolution_scale = floori(urs) #round 0.5 down
 	else:
 		resolution_scale = roundi(urs) #else round normally
-	if resolution_scale == 0: 
-		resolution_scale = 0.0001 #div by 0 protection
-
+	resolution_scale = max(resolution_scale, 1)
 
 	ui.scale = Vector2(resolution_scale, resolution_scale)
 	back.scale = Vector2(resolution_scale, resolution_scale)

--- a/src/World.tscn
+++ b/src/World.tscn
@@ -16,7 +16,6 @@ scroll_offset = Vector2(1184, 796)
 scroll_base_offset = Vector2(0, -2892)
 
 [node name="Back" type="Node2D" parent="."]
-scale = Vector2(4, 4)
 
 [node name="Middle" type="Node2D" parent="."]
 z_index = 1
@@ -28,15 +27,9 @@ z_index = 1
 process_mode = 3
 layer = 2
 visible = false
-scale = Vector2(4, 4)
-transform = Transform2D(4, 0, 0, 4, 0, 0)
 
 [node name="EditorLayer" type="CanvasLayer" parent="."]
 layer = 3
-scale = Vector2(2, 2)
-transform = Transform2D(2, 0, 0, 2, 0, 0)
 
 [node name="DebugLayer" type="CanvasLayer" parent="."]
 layer = 4
-scale = Vector2(2, 2)
-transform = Transform2D(2, 0, 0, 2, 0, 0)


### PR DESCRIPTION
Set default project resolution to 480x270 which is its true 1x res
Prevent resolution_scale from ever being less than 1
Set main_window minimum size to project
Remove "viewport size changed" print from World.gd
Fix Settings setting your window size to 1920x1080 every time
Fix world scales being pre-set in the editor when they should start at 1

Fixes #292