### PR TITLE
Fix Automatic Fire Mode for Guns resulting in numerous bugs

### DIFF
--- a/src/Gun/Gun.gd
+++ b/src/Gun/Gun.gd
@@ -31,19 +31,12 @@ var max_xp: int = 20
 var max_level: int = 1
 @export var level: int = 1
 
-
-var trigger_held = false
-
 @onready var world = get_tree().get_root().get_node("World")
 @onready var pc = get_parent().get_parent().get_parent()
 @onready var cd = pc.get_node("GunManager/CooldownTimer")
 
 
-
-
 func fire(type):
-	trigger_held = true
-	
 	if cd.time_left == 0:
 		if max_ammo == 0 or ammo != 0:
 			if max_ammo != 0:
@@ -56,21 +49,14 @@ func fire(type):
 
 		if not charging:
 			cd.start(cooldown_time)
-		
-		if type == "automatic":
-			await cd.timeout
-			if trigger_held:
-				fire("automatic")
 
 
 func release_manual_fire():
-	trigger_held = false
 	if charging:
 		cd.start(cooldown_time)
 	deactivate_manual()
 	
 func release_auto_fire():
-	trigger_held = false
 	deactivate_auto()
 
 

--- a/src/Player/GunManager.gd
+++ b/src/Player/GunManager.gd
@@ -11,31 +11,34 @@ var disabled = false #this is only because of a func in pc.ladder?
 func _ready():
 	set_guns_visible()
 
-func _input(event):
-	if not pc.disabled and !disabled and pc.can_input and $Guns.get_child_count() > 0:
-		if pc.mm.current_state == pc.mm.states["inspect"]: return
-		var active_gun = $Guns.get_child(0)
-		
-		if event.is_action_pressed("fire_manual"):
-			active_gun.fire("manual")
-		if event.is_action_pressed("fire_automatic") and active_gun.automatic:
-			active_gun.fire("automatic")
-		if event.is_action_released("fire_manual"):
-			active_gun.release_manual_fire()
-		if event.is_action_released("fire_automatic"):
-			active_gun.release_auto_fire()
+func _process(_delta: float) -> void:
+	if not can_shoot():
+		return
+	var active_gun = $Guns.get_child(0)
+	
+	if Input.is_action_just_pressed("fire_manual"):
+		active_gun.fire("manual")
+	if Input.is_action_pressed("fire_automatic") and active_gun.automatic:
+		active_gun.fire("automatic")
+	if Input.is_action_just_released("fire_manual"):
+		active_gun.release_manual_fire()
+	if Input.is_action_just_released("fire_automatic"):
+		active_gun.release_auto_fire()
 
-		if $Guns.get_child_count() > 1: #only swap if more than one gun
-			if event.is_action_pressed("gun_left"):
-				shift_gun("left")
-			if event.is_action_pressed("gun_right"):
-				shift_gun("right")
+	if $Guns.get_child_count() > 1: #only swap if more than one gun
+		if Input.is_action_just_pressed("gun_left"):
+			shift_gun("left")
+		if Input.is_action_just_pressed("gun_right"):
+			shift_gun("right")
 
-		if event.is_action_pressed("debug_level_up") and active_gun.level < active_gun.max_level:
-				level_up(true)
-		if event.is_action_pressed("debug_level_down") and active_gun.level != 1:
-				level_down(true)
+	if Input.is_action_just_pressed("debug_level_up") and active_gun.level < active_gun.max_level:
+			level_up(true)
+	if Input.is_action_just_pressed("debug_level_down") and active_gun.level != 1:
+			level_down(true)
 
+
+func can_shoot() -> bool:
+	return not pc.disabled and !disabled and pc.can_input and $Guns.get_child_count() > 0 and pc.mm.current_state != pc.mm.states["inspect"]
 
 ### METHODS
 


### PR DESCRIPTION
Fix guns getting stuck in autofire mode when swapping between them
GunManager now processes input in _process rather than _input to continuously fire() fully automatic guns.
This also fixes the ladder glitch where it continues firing the gun even though the gun manager is disabled
Do not use await in gun code
Add can_shoot() function to easily check if gun manager is allowed to shoot or not

Fixes https://github.com/AM-Mikey/Laputa/issues/278
Fixes https://github.com/AM-Mikey/Laputa/issues/328