### PR TITLE
transition iris fixes

### DIFF
--- a/src/Effect/Transition/TransitionIris.gd
+++ b/src/Effect/Transition/TransitionIris.gd
@@ -24,7 +24,7 @@ func _on_AnimationPlayer_animation_finished(anim_name):
 
 
 func _physics_process(_delta):
-	var vp_size = get_tree().get_root().size / world.resolution_scale
+	var vp_size = get_tree().get_root().size / vs.resolution_scale
 
 	var cam = pc.get_node("PlayerCamera")
 	if not cam.enabled:

--- a/src/Trigger/Door.gd
+++ b/src/Trigger/Door.gd
@@ -46,7 +46,7 @@ func enter_door():
 
 	var transition = TRANSITION.instantiate()
 	if w.bl.has_node("TransitionIris"):
-		w.bl.get_node("BlackoutLayer/TransitionIris").free()
+		w.bl.get_node("TransitionIris").free()
 	w.bl.add_child(transition)
 
 	await transition.get_node("AnimationPlayer").animation_finished

--- a/src/World.tscn
+++ b/src/World.tscn
@@ -94,6 +94,5 @@ libraries = {
 
 [node name="BlackoutLayer" type="CanvasLayer" parent="."]
 process_mode = 3
-visible = false
 scale = Vector2(4, 4)
 transform = Transform2D(4, 0, 0, 4, 0, 0)


### PR DESCRIPTION
iris pulls correct resolution scale, door.gd references the iris correctly and doesn't crash the game, made blackoutlayer visible by default(intended?)