### PR TITLE
Make beetle stick closer to the walls

### DIFF
--- a/src/Actor/Enemy/BeetleCrawler.gd
+++ b/src/Actor/Enemy/BeetleCrawler.gd
@@ -58,6 +58,16 @@ func _on_physics_process(_delta):
 	#if (state == "turn_edge"):
 		#velocity += wall_dir * 10.0
 
+	if state == "crawl":
+		# Prevent pixel gaps between the beetle and the terrain by making the beetle
+		# stick closer to the wall
+		var collision := move_and_collide(wall_dir * 5, true)
+		# The first move_and_collide doesn't move the body, instead it tests if
+		# the body *would* collide if moved
+		if collision != null:
+			if collision.get_travel().length() > 0.0001:
+				move_and_collide(wall_dir * 5)
+
 	move_and_slide()
 
 


### PR DESCRIPTION
Kiiiind of an ugly band-aid fix, but it does the job! If you want to make a proper fix instead of merging this, understandable.

Fixes https://github.com/AM-Mikey/Laputa/issues/507

https://github.com/user-attachments/assets/7fe81e3c-a49b-46a9-b2c0-7d188cfd859a

Note: the beetle still occasionally has a pixel gap briefly after turning around a corner. If you want to fix this, the way to go is to make the beetle initiate the turning animation at *precisely* the correct moment