### PR TITLE
Fix error when adding sentry bullet to scene

### DIFF
--- a/src/Actor/Enemy/Sentry.gd
+++ b/src/Actor/Enemy/Sentry.gd
@@ -70,7 +70,7 @@ func prepare_bullet():
 	bullet.position = Vector2($CollisionShape2D.global_position.x, $CollisionShape2D.global_position.y - height_tolerance)
 	bullet.direction = Vector2(look_dir.x / 2.0, -1) #Adjust this for angle
 
-	w.middle.add_child(bullet)
+	w.middle.add_child.call_deferred(bullet)
 
 
 


### PR DESCRIPTION
Addresses a part of https://github.com/AM-Mikey/Laputa/issues/449

Without this fix, you sometimes get this error when the sentry spawns in a bullet: 
<img width="1165" height="25" alt="image" src="https://github.com/user-attachments/assets/c0eab1b5-9be3-41c9-addf-c23078be1581" />

...not sure if this fix does anything to the displacement itself.